### PR TITLE
Add quarkus-apache-httpclient dependency to fix the native build

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -14,6 +14,10 @@
       <artifactId>quarkus-arc-deployment</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-apache-httpclient-deployment</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.logging.cloudwatch</groupId>
       <artifactId>quarkus-logging-cloudwatch</artifactId>
       <version>${project.version}</version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,6 +14,10 @@
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-apache-httpclient</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-logs</artifactId>
     </dependency>


### PR DESCRIPTION
This extension sets up the necessary native config when using the Apache
HTTP Client, which this extension uses.

After this PR, the build passes for GraalVM 21.1 and the Ecosystem CI should be green again.