### PR TITLE
Add config keys to prevent memory leak

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
@@ -16,6 +16,7 @@
  */
 package io.quarkiverse.logging.cloudwatch;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -70,6 +71,27 @@ public class LoggingCloudWatchConfig {
      */
     @ConfigItem(defaultValue = "WARN")
     public Level level;
+
+    /**
+     * Number of log events sent to CloudWatch per batch.
+     * Defaults to 10,000 which is the maximum number of log events per batch allowed by CloudWatch.
+     */
+    @ConfigItem(defaultValue = "10000")
+    public int batchSize;
+
+    /**
+     * Period between two batch executions.
+     * Defaults to 5 seconds.
+     */
+    @ConfigItem(defaultValue = "5s")
+    public Duration batchPeriod;
+
+    /**
+     * Maximum size of the log events queue.
+     * If this is not set, the queue will have a capacity of {@link Integer#MAX_VALUE}.
+     */
+    @ConfigItem
+    public Optional<Integer> maxQueueSize;
 
     /*
      * We need to validate that the values are present, even if marked as optional.

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
@@ -55,7 +55,7 @@ public class LoggingCloudWatchHandlerValueFactory {
         String token = createLogStreamIfNeeded(awsLogs, config);
 
         LoggingCloudWatchHandler handler = new LoggingCloudWatchHandler(awsLogs, config.logGroup.get(),
-                config.logStreamName.get(), token);
+                config.logStreamName.get(), token, config.maxQueueSize, config.batchSize, config.batchPeriod);
         handler.setLevel(config.level);
 
         return new RuntimeValue<>(Optional.of(handler));


### PR DESCRIPTION
The extension currently leaks memory because of an [upstream issue](https://github.com/aws/aws-sdk-java/issues/2807) when a batch exceeds the maximum size allowed by CloudWatch.

This PR introduces 3 new configuration keys that can be used to better deal with big log messages and also work around the memory leak:
- `quarkus.log.cloudwatch.batch-size` should be used whenever the app logs messages that are big enough to exceed the maximum batch size allowed by CloudWatch.
- `quarkus.log.cloudwatch.batch-period` can be lowered to increase the frequency of pushes to CloudWatch and prevent an accumulation of log events in the queue because of a low batch size. CloudWatch accepts up to 5 requests per second according to their Javadoc.
- `quarkus.log.cloudwatch.max-queue-size` can be used to limit the total amount of memory used by the extension. New log events won't be inserted if that limit is reached, until old log events are removed from the queue. Warnings will also be logged showing that there is a problem that requires the devs attention.