### PR TITLE
Use Quarkus Log API

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/logging/cloudwatch/it/LoggingCloudwatchHandlerResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/logging/cloudwatch/it/LoggingCloudwatchHandlerResource.java
@@ -20,19 +20,18 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
+
+import io.quarkus.logging.Log;
 
 @Path("/logging-cloudwatch")
 @ApplicationScoped
 public class LoggingCloudwatchHandlerResource {
 
-    private static final Logger logger = Logger.getLogger(LoggingCloudwatchHandlerResource.class);
-
     @GET
     public String hello() {
         MDC.put("mdc-key", "mdc-value");
-        logger.info("hello cloudwatch");
+        Log.info("hello cloudwatch");
 
         return "Hello logging-cloudwatch";
     }

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandler.java
@@ -26,7 +26,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.*;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
 
 import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.model.InputLogEvent;
@@ -35,10 +36,9 @@ import com.amazonaws.services.logs.model.PutLogEventsRequest;
 import com.amazonaws.services.logs.model.PutLogEventsResult;
 
 import io.quarkiverse.logging.cloudwatch.format.ElasticCommonSchemaLogFormatter;
+import io.quarkus.logging.Log;
 
 class LoggingCloudWatchHandler extends Handler {
-
-    private static final Logger LOGGER = Logger.getLogger("LoggingCloudWatch");
 
     private AWSLogs awsLogs;
     private String logStreamName;
@@ -89,7 +89,7 @@ class LoggingCloudWatchHandler extends Handler {
         // Queue this up, so that it can be flushed later in batch asynchronously
         boolean inserted = eventBuffer.offer(logEvent);
         if (!inserted) {
-            LOGGER.warning(
+            Log.warn(
                     "Maximum size of the CloudWatch log events queue reached. Consider increasing that size from the configuration.");
         }
     }
@@ -107,10 +107,10 @@ class LoggingCloudWatchHandler extends Handler {
 
     @Override
     public void close() throws SecurityException {
-        LOGGER.info("Shutting down and awaiting termination");
+        Log.info("Shutting down and awaiting termination");
         shutdownAndAwaitTermination(scheduler);
 
-        LOGGER.info("Trying to send of last log messages after shutdown.");
+        Log.info("Trying to send of last log messages after shutdown.");
         publisher.run();
     }
 
@@ -143,10 +143,10 @@ class LoggingCloudWatchHandler extends Handler {
                         counter = 10;
                     } catch (InvalidSequenceTokenException e) {
                         String exceptionMessage = e.getMessage();
-                        LOGGER.info("exception message: " + exceptionMessage);
+                        Log.infof("exception message: %s", exceptionMessage);
 
                         sequenceToken = extractValidSequenceToken(exceptionMessage);
-                        LOGGER.info("extracted sequence token: " + sequenceToken);
+                        Log.infof("extracted sequence token: %s", sequenceToken);
 
                         workingSequenceToken = false;
                     }
@@ -157,7 +157,7 @@ class LoggingCloudWatchHandler extends Handler {
 
         private int checkAndIncreaseCounter(int counter) {
             if (counter == 9) {
-                LOGGER.severe("Last counter iteration now. Too many attempts. Will abort trying now. ");
+                Log.error("Last counter iteration now. Too many attempts. Will abort trying now.");
             }
             counter++;
             return counter;

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
@@ -19,7 +19,6 @@ package io.quarkiverse.logging.cloudwatch;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Handler;
-import java.util.logging.Logger;
 
 import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.AWSLogsClientBuilder;
@@ -28,24 +27,23 @@ import com.amazonaws.services.logs.model.DescribeLogStreamsRequest;
 import com.amazonaws.services.logs.model.LogStream;
 
 import io.quarkiverse.logging.cloudwatch.auth.CloudWatchCredentialsProvider;
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class LoggingCloudWatchHandlerValueFactory {
 
-    private static final Logger LOGGER = Logger.getLogger("LoggingCloudWatch");
-
     public RuntimeValue<Optional<Handler>> create(final LoggingCloudWatchConfig config) {
         if (!config.enabled) {
-            LOGGER.info("Quarkus Logging Cloudwatch Extension is not enabled");
+            Log.info("Quarkus Logging Cloudwatch Extension is not enabled");
             return new RuntimeValue<>(Optional.empty());
         }
 
         config.validate();
 
-        LOGGER.info("Initializing Quarkus Logging Cloudwatch Extension");
-        LOGGER.info("Logging to log-group: " + config.logGroup.get() + " and log-stream: " + config.logStreamName.get());
+        Log.info("Initializing Quarkus Logging Cloudwatch Extension");
+        Log.infof("Logging to log-group: %s and log-stream: %s", config.logGroup.get(), config.logStreamName.get());
 
         AWSLogsClientBuilder clientBuilder = AWSLogsClientBuilder.standard();
         clientBuilder.setCredentials(new CloudWatchCredentialsProvider(config));


### PR DESCRIPTION
This PR replaces all JUL/JBoss loggers invocations with the Quarkus `Log` API.