### PR TITLE
Replace deprecated Quarkus plugin

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -44,7 +44,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixes
```
[INFO] --- quarkus-bootstrap-maven-plugin:2.11.2.Final:extension-descriptor (default) @ quarkus-logging-cloudwatch ---
[WARNING] This Maven plugin was deprecated in favor of io.quarkus:quarkus-extension-maven-plugin:2.11.2.Final, please, update the artifactId of the plugin in your project configuration.
```