### PR TITLE
Migrate to software.amazon.awssdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>2.12.2.Final</quarkus.version>
-        <aws.version>1.12.305</aws.version>
+        <awssdk.version>2.17.280</awssdk.version>
         <aws.common.version>1.2.0</aws.common.version>
     </properties>
     <dependencyManagement>
@@ -36,9 +36,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws.version}</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -22,8 +22,8 @@
             <artifactId>quarkus-amazon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-logs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
         </dependency>
         <dependency>
             <groupId>co.elastic.logging</groupId>

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/auth/CloudWatchCredentials.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/auth/CloudWatchCredentials.java
@@ -16,11 +16,10 @@
  */
 package io.quarkiverse.logging.cloudwatch.auth;
 
-import com.amazonaws.auth.AWSCredentials;
-
 import io.quarkiverse.logging.cloudwatch.LoggingCloudWatchConfig;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
-class CloudWatchCredentials implements AWSCredentials {
+class CloudWatchCredentials implements AwsCredentials {
 
     private final LoggingCloudWatchConfig config;
 
@@ -29,12 +28,12 @@ class CloudWatchCredentials implements AWSCredentials {
     }
 
     @Override
-    public String getAWSAccessKeyId() {
+    public String accessKeyId() {
         return config.accessKeyId.get();
     }
 
     @Override
-    public String getAWSSecretKey() {
+    public String secretAccessKey() {
         return config.accessKeySecret.get();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/auth/CloudWatchCredentialsProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/auth/CloudWatchCredentialsProvider.java
@@ -16,12 +16,11 @@
  */
 package io.quarkiverse.logging.cloudwatch.auth;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-
 import io.quarkiverse.logging.cloudwatch.LoggingCloudWatchConfig;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
-public class CloudWatchCredentialsProvider implements AWSCredentialsProvider {
+public class CloudWatchCredentialsProvider implements AwsCredentialsProvider {
 
     private final LoggingCloudWatchConfig config;
 
@@ -30,11 +29,7 @@ public class CloudWatchCredentialsProvider implements AWSCredentialsProvider {
     }
 
     @Override
-    public AWSCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         return new CloudWatchCredentials(config);
-    }
-
-    @Override
-    public void refresh() {
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.logging.cloudwatch;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.logging.LogRecord;
 
@@ -10,26 +11,6 @@ import org.junit.jupiter.api.Test;
 class LoggingCloudWatchHandlerTest {
 
     private final LoggingCloudWatchHandler testee = new LoggingCloudWatchHandler();
-
-    @Test
-    void shouldExtractNextSequenceToken() {
-        Exception e = new RuntimeException(
-                "The given sequenceToken is invalid. The next expected sequenceToken is: 49611889230645343415657219696041834137426496333583221330 (Service: AWSLogs; Status Code: 400; Error Code: InvalidSequenceTokenException; Request ID: 02120a3d-bc00-45df-96fd-b3491ba01924; Proxy: null)");
-        String exceptionMessage = e.getMessage();
-        final String actual = testee.extractValidSequenceToken(exceptionMessage);
-
-        assertEquals("49611889230645343415657219696041834137426496333583221330", actual);
-    }
-
-    @Test
-    void shouldExtractNextSequenceTokenWhenThereAreBlanks() {
-        Exception e = new RuntimeException(
-                "The given sequenceToken is invalid. The next expected sequenceToken is:  49611889230645343415657219696041834137426496333583221330  (Service: AWSLogs; Status Code: 400; Error Code: InvalidSequenceTokenException; Request ID: 02120a3d-bc00-45df-96fd-b3491ba01924; Proxy: null)");
-        String exceptionMessage = e.getMessage();
-        final String actual = testee.extractValidSequenceToken(exceptionMessage);
-
-        assertEquals("49611889230645343415657219696041834137426496333583221330", actual);
-    }
 
     @Test
     void shouldBeBelowThresholdWhenBothAreInfo() {


### PR DESCRIPTION
The `software.amazon.awssdk` group contains the dependencies for version 2 of the AWS SDK for Java.

I need to test this locally first. This PR will remain a draft until then.