### PR TITLE
RHCLOUD-23850 Prevent never-ending calls to the CloudWatch API

### DIFF
--- a/docs/modules/ROOT/pages/config.adoc
+++ b/docs/modules/ROOT/pages/config.adoc
@@ -109,4 +109,16 @@ Optional service environment added to each log record when available.
 --|string
 |
 
+
+a| [[quarkus-log-cloudwatch-api-call-timeout]]`link:#quarkus-log-cloudwatch-api-call-timeout[quarkus.log.cloudwatch.api-call-timeout]`
+
+[.description]
+--
+Optional amount of time to allow the CloudWatch client to complete the execution of an API call.
+This timeout covers the entire client execution except for marshalling.
+This includes request handler execution, all HTTP requests including retries, unmarshalling, etc.
+This value should always be positive, if present.
+--|Duration
+|
+
 |===

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
@@ -101,6 +101,14 @@ public class LoggingCloudWatchConfig {
     @ConfigItem
     public Optional<String> serviceEnvironment;
 
+    /**
+     * Amount of time to allow the CloudWatch client to complete the execution of an API call. This timeout covers the
+     * entire client execution except for marshalling. This includes request handler execution, all HTTP requests
+     * including retries, unmarshalling, etc. This value should always be positive, if present.
+     */
+    @ConfigItem
+    public Optional<Duration> apiCallTimeout;
+
     /*
      * We need to validate that the values are present, even if marked as optional.
      * We need to mark them as optional, as otherwise the config would mark them


### PR DESCRIPTION
When `CloudWatchLogsClient#putLogEvents` is executed by this extension with a payload that exceeds the maximum size allowed by CloudWatch, the extension will log one of the following error messages and continue working as expected.

```
PutLogEvents call failed, log events from the current batch will not be sent to CloudWatch: software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException: Upload too large: 1054510 bytes exceeds limit of 1048576 (Service: CloudWatchLogs, Status Code: 400, Request ID: xxxxxxxx)
        at io.quarkiverse.logging.cloudwatch.LoggingCloudWatchHandler$Publisher.run(LoggingCloudWatchHandler.java:159)
```
```
PutLogEvents call failed, log events from the current batch will not be sent to CloudWatch: software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException: Service returned HTTP status code 413 (Service: CloudWatchLogs, Status Code: 413, Request ID: null)
        at io.quarkiverse.logging.cloudwatch.LoggingCloudWatchHandler$Publisher.run(LoggingCloudWatchHandler.java:159)
```
On rare occasions, the `CloudWatchLogsClient#putLogEvents` call never stops, preventing any further execution and leading to a memory leak because the log entries are accumulating into the application memory and can never be sent to CloudWatch.

This PR introduces a new config key that allows an application to set an API call timeout, ensuring that no call to CloudWatch will ever be stuck forever.