### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -31,8 +31,8 @@
             <version>1.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145