### PR TITLE
Adds the ability to truncate messages based on a max length parameter

### DIFF
--- a/deployment/src/test/resources/application.properties
+++ b/deployment/src/test/resources/application.properties
@@ -6,3 +6,4 @@ quarkus.log.cloudwatch.region=eu-central-1
 quarkus.log.cloudwatch.log-group=logGroup
 quarkus.log.cloudwatch.log-stream-name=logStreamName
 quarkus.log.cloudwatch.level=WARN
+quarkus.log.cloudwatch.max-message-length=0

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchConfig.java
@@ -127,6 +127,15 @@ public interface LoggingCloudWatchConfig {
     @WithName("endpoint-override")
     Optional<String> endpointOverride();
 
+    /**
+     * Max message length
+     * The message will be truncated if it exceeds this value.
+     * 0 means no limit.
+     */
+    @WithName("max-message-length")
+    @WithDefault("0")
+    int maxMessageLength();
+
     /*
      * We need to validate that the values are present, even if marked as optional.
      * We need to mark them as optional, as otherwise the config would mark them

--- a/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/logging/cloudwatch/LoggingCloudWatchHandlerValueFactory.java
@@ -81,7 +81,7 @@ public class LoggingCloudWatchHandlerValueFactory {
 
         LoggingCloudWatchHandler handler = new LoggingCloudWatchHandler(cloudWatchLogsClient, config.logGroup().get(),
                 config.logStreamName().get(), token, config.maxQueueSize(), config.batchSize(), config.batchPeriod(),
-                config.serviceEnvironment());
+                config.serviceEnvironment(), config.maxMessageLength());
         handler.setLevel(config.level());
 
         return new RuntimeValue<>(Optional.of(handler));


### PR DESCRIPTION
This feature should avoid loosing entire messages when they are too long.
Error like:
`software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException: Upload too large: 1048921 bytes exceeds limit of 1048576 (Service: CloudWatchLogs, Status Code: 400) (SDK Attempt Count: 1)`