### PR TITLE
Fix ClassNotFoundException at application startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,17 +34,17 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${quarkus.version}</version>
+        <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>bom</artifactId>
-        <version>${awssdk.version}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This PR should fix
```
ERROR: Failed to start application
java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:119)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:80)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:51)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:144)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:69)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:37)
Caused by: java.lang.NoClassDefFoundError: software/amazon/awssdk/awscore/auth/AuthSchemePreferenceResolver
	at software.amazon.awssdk.services.cloudwatchlogs.DefaultCloudWatchLogsBaseClientBuilder.defaultAuthSchemeProvider(DefaultCloudWatchLogsBaseClientBuilder.java:140)
	at software.amazon.awssdk.services.cloudwatchlogs.DefaultCloudWatchLogsBaseClientBuilder.lambda$mergeServiceDefaults$0(DefaultCloudWatchLogsBaseClientBuilder.java:76)
	at software.amazon.awssdk.utils.builder.SdkBuilder.applyMutation(SdkBuilder.java:61)
	at software.amazon.awssdk.core.client.config.SdkClientConfiguration.merge(SdkClientConfiguration.java:98)
	at software.amazon.awssdk.services.cloudwatchlogs.DefaultCloudWatchLogsBaseClientBuilder.mergeServiceDefaults(DefaultCloudWatchLogsBaseClientBuilder.java:74)
	at software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.mergeChildDefaults(AwsDefaultClientBuilder.java:139)
	at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.syncClientConfiguration(SdkDefaultClientBuilder.java:198)
	at software.amazon.awssdk.services.cloudwatchlogs.DefaultCloudWatchLogsClientBuilder.buildClient(DefaultCloudWatchLogsClientBuilder.java:38)
	at software.amazon.awssdk.services.cloudwatchlogs.DefaultCloudWatchLogsClientBuilder.buildClient(DefaultCloudWatchLogsClientBuilder.java:25)
	at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.build(SdkDefaultClientBuilder.java:169)
	at io.quarkiverse.logging.cloudwatch.LoggingCloudWatchHandlerValueFactory.create(LoggingCloudWatchHandlerValueFactory.java:78)
	at io.quarkus.runner.recorded.LoggingCloudwatchProcessor$addCloudwatchLogHandler1443904689.deploy_0(Unknown Source)
	at io.quarkus.runner.recorded.LoggingCloudwatchProcessor$addCloudwatchLogHandler1443904689.deploy(Unknown Source)
	... 9 more
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.awscore.auth.AuthSchemePreferenceResolver
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:114)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:72)
	... 22 more
```
Related issue: https://github.com/aws/aws-sdk-java-v2/issues/6168